### PR TITLE
Changing Telegram URL issue #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ We follow project-based learning and we will work on all the projects in paralle
 https://bit.ly/3qxKEFP
 
 #### Join Telegram for Data Science ML AI Resources:
-https://bit.ly/3qxKEFP
+https://t.me/+sREuRiFssMo4YWJl
 
 Connect with me on these platforms:
 


### PR DESCRIPTION
WhatsApp Group URL and Telegram Group URL were the same described in issue #2. I worked on it and correct the Telegram URL.